### PR TITLE
Add .gitignore to exclude cloned claude-mem directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+claude-mem/


### PR DESCRIPTION
## Summary
- Added `.gitignore` to exclude the externally cloned `claude-mem/` directory from being tracked in this repository

## Test plan
- [ ] Verify `claude-mem/` no longer appears as untracked in `git status`

https://claude.ai/code/session_01KgUa3dsi6XtzW9mg1LiyNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgUa3dsi6XtzW9mg1LiyNR)_